### PR TITLE
Rehome at cuttlefacts org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
-# Cuttlefacts (with Argo)
+# Cuttlefacts infrastructure (with Argo)
 
-This is a companion to [squaremo/cuttlefacts](https://github.com/squaremo/cuttlefacts/), using [Argo kit](https://github.com/argoproj/) instead of Tekton to drive application delivery pipelines. [Flux](https://github.com/fluxcd/flux) is still used to bootstrap the infrastructure.
+This is a companion to
+[cuttlefacts/cuttlefacts](https://github.com/cuttlefacts/cuttlefacts/),
+using [Argo kit](https://github.com/argoproj/) instead of Tekton to
+drive application delivery
+pipelines. [Flux](https://github.com/fluxcd/flux) is still used to
+bootstrap the infrastructure.

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -4,5 +4,5 @@ This layer exists to bootstrap the infrastructure and maintain the
 infrastructure of the cluster (including itself).
 
 The files in here were copied from
-[squaremo/cuttlefacts/substructure](https://github.com/squaremo/cuttlefacts/tree/master/substructure)
+[cuttlefacts/cuttlefacts/substructure](https://github.com/cuttlefacts/cuttlefacts/tree/master/substructure)
 and adapted minorly to change the namespace.

--- a/bootstrap/flux.yaml
+++ b/bootstrap/flux.yaml
@@ -135,7 +135,7 @@ spec:
         # Replace the following URL to change the Git repository used by Flux.
         # HTTP basic auth credentials can be supplied using environment variables:
         # https://$(GIT_AUTHUSER):$(GIT_AUTHKEY)@github.com/user/repository.git
-        - --git-url=https://github.com/squaremo/cuttlefacts-argo
+        - --git-url=https://github.com/cuttlefacts/cuttlefacts-argo
         - --git-branch=master
         - --git-path=bootstrap
         - --git-path=platform


### PR DESCRIPTION
Change stuff to point at cuttlefacts/ rather than squaremo/

Remarkably little needs to change.