### PR TITLE
Workflow to update image in manifest

### DIFF
--- a/platform/cuttlefacts-update.yaml
+++ b/platform/cuttlefacts-update.yaml
@@ -1,0 +1,116 @@
+---
+# Workflow to update the manifest in the git repo, when a new
+# image is pushed.
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: cuttlefacts-update-
+  namespace: platform
+spec:
+  entrypoint: update-and-push
+  volumes:
+  - name: repo-key
+    secret:
+      secretName: cuttlefacts-repo-secret
+      defaultMode: 0400
+  templates:
+  - name: update-and-push
+    steps:
+    - - name: call-update
+        template: update
+        arguments:
+          parameters:
+          - name: file
+            value: /workspace/source/apps/cuttlefacts/deployment.yaml
+          - name: image
+            value: docker.pkg.github.com/cuttlefacts/cuttlefacts-argo.cuttlefacts-app:v2
+          artifacts:
+          - name: source
+            git:
+              repo: git@github.com:cuttlefacts/cuttlefacts-argo
+              revision: master
+              sshPrivateKeySecret:
+                name: cuttlefacts-repo-secret
+                key: id_rsa
+
+    - - name: call-commit-and-push
+        template: commit-and-push
+        arguments:
+          parameters:
+          - name: file
+            value: /workspace/source/apps/cuttlefacts/deployment.yaml
+          - name: message
+            value: Update to cuttlefacts v2
+          - name: content
+            value: "{{steps.call-update.outputs.result}}"
+          artifacts:
+          - name: source
+            git:
+              repo: git@github.com:cuttlefacts/cuttlefacts-argo
+              revision: master
+              sshPrivateKeySecret:
+                name: cuttlefacts-repo-secret
+                key: id_rsa
+
+  - name: update
+    inputs:
+      parameters:
+      - name: image
+      - name: file
+      artifacts:
+      - name: source
+        path: /workspace/source
+    script:
+      image: quay.io/squaremo/kubeyaml:0.7.0
+      command:
+      - /bin/sh
+      source: |
+        set -e
+        set -o pipefail
+
+        echo "==> updating file " {{inputs.parameters.file}} >&2
+        echo " with content:" >&2
+        cat {{inputs.parameters.file}} | \
+          /usr/lib/kubeyaml/kubeyaml image \
+            --namespace=cuttlefacts \
+              --kind=Deployment \
+              --name=cuttlefacts \
+              --container=server \
+              --image="{{inputs.parameters.image}}"
+        echo "... done." >&2
+
+  - name: commit-and-push
+    inputs:
+      parameters:
+      - name: file
+      - name: message
+      - name: content
+      artifacts:
+      - name: source
+        path: /workspace/source
+    script:
+      image: alpine/git:v2.24.1
+      volumeMounts:
+      - name: repo-key
+        mountPath: /root/.ssh/
+      command:
+      - /bin/sh
+      source: |
+        set -e
+        set -o pipefail
+
+        cd /workspace/source
+        git config user.email "squaremobot@users.noreply.github.com"
+        git config user.name  "squaremobot"
+
+        echo "==> Writing update to {{inputs.parameters.file}}" >&2
+        echo "{{inputs.parameters.content}}" > "{{inputs.parameters.file}}"
+        echo "==> Diff" >&2
+        git diff
+        echo >&2
+        echo "==> Committing" >&2
+        git add {{inputs.parameters.file}}
+        git commit -m "{{inputs.parameters.message}}"
+        git remote -v
+        GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -v" git push
+        echo Done. >&2

--- a/platform/cuttlefacts-update.yaml
+++ b/platform/cuttlefacts-update.yaml
@@ -2,17 +2,17 @@
 # Workflow to update the manifest in the git repo, when a new
 # image is pushed.
 apiVersion: argoproj.io/v1alpha1
-kind: Workflow
+kind: WorkflowTemplate
 metadata:
-  generateName: cuttlefacts-update-
+  name: cuttlefacts-update
   namespace: platform
 spec:
   entrypoint: update-and-push
-  volumes:
-  - name: repo-key
-    secret:
-      secretName: cuttlefacts-repo-secret
-      defaultMode: 0400
+
+  # Volumes get defined in the _calling_ workflow
+
+  # Do the workflow arguments get supplied by the Workflow too? Yes.
+
   templates:
   - name: update-and-push
     steps:
@@ -21,9 +21,9 @@ spec:
         arguments:
           parameters:
           - name: file
-            value: /workspace/source/apps/cuttlefacts/deployment.yaml
+            value: "{{workflow.parameters.file}}"
           - name: image
-            value: docker.pkg.github.com/cuttlefacts/cuttlefacts-argo.cuttlefacts-app:v2
+            value: "{{workflow.parameters.image}}"
           artifacts:
           - name: source
             git:
@@ -38,9 +38,9 @@ spec:
         arguments:
           parameters:
           - name: file
-            value: /workspace/source/apps/cuttlefacts/deployment.yaml
+            value: "{{workflow.parameters.file}}"
           - name: message
-            value: Update to cuttlefacts v2
+            value: "{{workflow.parameters.message}}"
           - name: content
             value: "{{steps.call-update.outputs.result}}"
           artifacts:
@@ -68,9 +68,10 @@ spec:
         set -e
         set -o pipefail
 
+        cd "{{inputs.artifacts.source.path}}"
         echo "==> updating file " {{inputs.parameters.file}} >&2
         echo " with content:" >&2
-        cat {{inputs.parameters.file}} | \
+        cat "{{inputs.parameters.file}}" | \
           /usr/lib/kubeyaml/kubeyaml image \
             --namespace=cuttlefacts \
               --kind=Deployment \
@@ -99,7 +100,7 @@ spec:
         set -e
         set -o pipefail
 
-        cd /workspace/source
+        cd "{{inputs.artifacts.source.path}}"
         git config user.email "squaremobot@users.noreply.github.com"
         git config user.name  "squaremobot"
 


### PR DESCRIPTION
This adds a workflow which will update the image used in the
cuttlefacts-app deployment. It will run, but there are a bunch of
problems with it:

 - it's a Workflow, rather than a WorkflowTemplate, so it can't be
   invoked by a Events sensor (at least not easily, to my knowledge)

 - pretty much everything is hardwired -- there's no parameterisation
   of the whole workflow

 - I have to mount the deploy key secret into the container which
   pushes to git

All of these stem from limitations of Argo Workflow, or my ability to
interpret the workings thereof.

To  elaborate on some of the items mentioned above:

**It's a Workflow rather than a workflow template**

As I understand it, the general idea with WorkflowTemplates is that you can specify a bunch of separate templates, then string them together in a Workflow later. This has some limitations, though:

 - you can't parameterise a template with steps; so, you can't have a template with steps in a WorkflowTemplate and expect to be able to invoke it from a Workflow, with parameters. In my case, I can't have a WorkflowTemplate that does the update then commits and pushes it, then invoke that in an events sensor with the particulars. This ends up making WorkflowTemplates pretty useless, since you have to put all the stringing-together into the Workflow anyway.

 - you can pass output parameters from one template to another's inputs, but you can't do the same with e.g., directories unless you go via an "artifact store". This is kind of fair enough, but a bit of a pain. In my case, it led me to some contortions in which I print the updated file to stdout in one step, then retrieve it to overwrite the same file in another step. It'd be nice to just alter the filesystem in one step and commit the change in another.

**pretty much everything is hard-wired**

To some extent this is just because I want to get it working. But it's also because the system for passing parameters seems confusing and inconsistent. Not to mention, programming in YAML is a complete disaster.

**I have to mount the deploy key secret**

Ideally I'd want to have the system clone the git repo for me, then I can make some changes in place, and assuming I provided suitable credentials, I can push commits back up.

But that doesn't seem to be the way it works -- the credentials given to the system are mounted in a place specific to the system, and used (available?) only by the initialisation process. I can see reasons why this might be desirable -- maybe you don't want to expose those details to a workflow container (which can be parameterised by the input repo). But it's a pain for me.
